### PR TITLE
Delivery of #26

### DIFF
--- a/.test.env
+++ b/.test.env
@@ -4,5 +4,6 @@ LDAP_CONFIG_PASSWORD=config
 LDAP_DOMAIN=sram.tld
 LDAP_BASE_DN=dc=sram,dc=tld
 LDAP_BIND_DN=cn=admin,dc=sram,dc=tld
+LDAP_SIZELIMIT=50
 
 SBS_API_RECORDING=Yes

--- a/plsc.yml.example
+++ b/plsc.yml.example
@@ -5,11 +5,13 @@ ldap:
     basedn: dc=scz,dc=vnet
     binddn: cn=admin,dc=scz,dc=vnet
     passwd: changethispassword
+    sizelimit: 500
   dst:
     uri: ldap://ldap.vm.scz-vm.net
     basedn: dc=services,dc=vnet
     binddn: cn=admin,dc=clients,dc=vnet
     passwd: changethispassword
+    sizelimit: 500
 sbs:
   src:
     host: https://sbs.example.net

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 log_cli = true
-log_cli_level = INFO
+log_cli_level = ERROR
 env_files =
     .env
     .test.env

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -64,7 +64,8 @@ class BaseTest(TestCase):
         'uri': os.environ["LDAP_URL"],
         'basedn': os.environ["LDAP_BASE_DN"],
         'binddn': os.environ["LDAP_BIND_DN"],
-        'passwd': os.environ["LDAP_ADMIN_PASSWORD"]
+        'passwd': os.environ["LDAP_ADMIN_PASSWORD"],
+        'sizelimit': int(os.environ.get("LDAP_SIZELIMIT", 500))
     }
 
     @classmethod


### PR DESCRIPTION
Implements Pages LDAP searches. sizelimit can be expressed in plsc.yml (see plsc.example)
This limit should be less/equal to LDAP server sizelimit, which is default 500)
The size limit will be used to read LDAP in pages of max 'sizelimit' objects.