### PR TITLE
Add dry-run

### DIFF
--- a/plsc.yml.example
+++ b/plsc.yml.example
@@ -15,6 +15,8 @@ ldap:
 sbs:
   src:
     host: https://sbs.example.net
+    # host: test
+    # sync: sync.json
     user: sysread
     passwd: changethispassword
     verify_ssl: True

--- a/sbs.py
+++ b/sbs.py
@@ -37,6 +37,9 @@ class SBS(object):
         self.retry = config.get('retry', 3)
         self.recording_requested = config.get('recorder', False)
 
+        if self.host == 'test':
+            self.sync = config['sync']
+
         if config.get("ipv4_only", False):
             import urllib3.util.connection as urllib3_connection
 
@@ -68,6 +71,9 @@ class SBS(object):
             pass
 
         logger.debug(f"API: {request}...")
+
+        if self.host == 'test' and request == 'api/plsc/sync':
+            return json.loads(open(self.sync, 'r').read())
 
         # retry the entire process a few times`
         for i in range(0, self.retry):


### PR DESCRIPTION
This PR adds the option to specify `'test'` as SBS host and a `sync` key to point to a local file containing the `/api/plsc/sync` endpoint to test against in json format:
```
...
sbs:
  src:
    # host: https://sbs.example.net
    host: test
    sync: sync.json
...
```