### PR TITLE
updates emails for sram tools contact fetch script

### DIFF
--- a/emails.py
+++ b/emails.py
@@ -78,6 +78,35 @@ def fetch_contacts(src: SBS, org: bool = True, co: bool = True, service: bool = 
                 "mail": srvc['contact_email']
             })
 
+            if 'security_email' in srvc:
+                contacts.append({
+                "type": "service",
+                "id": s_id,
+                "name": srvc['name'],
+                "role": "sp-security",
+                "mail": srvc['security_email']
+            })
+
+            if 'support_email' in srvc:
+                contacts.append({
+                "type": "service",
+                "id": s_id,
+                "name": srvc['name'],
+                "role": "sp-suport",
+                "mail": srvc['support_email']
+            })
+            
+            # append service manager and service admin emails
+            for user in srvc['service_memberships']:
+                contacts.append({
+                    "type": "service",
+                    "id": s_id,
+                    "name": srvc['name'],
+                    "role": "sp" + user['role'],
+                    "mail": user['user']['email']
+                })
+                
+
     if co:
         collaborations = src.collaborations()
         for collaboration in collaborations:


### PR DESCRIPTION
This PR adds the logic to include sp-security, sp-support,  sp-admin, and sp-manager contact emails in the CSV and XLSX reports used by tools.sram.surf.nl

Fixes https://github.com/SURFscz/SBS/issues/910