### PR TITLE
Add feedback on start of process script

### DIFF
--- a/misc/process.sh
+++ b/misc/process.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+echo "PLSC loop started"
 while true
 do
     sleep 5m


### PR DESCRIPTION
The container starts with a 5 minute delay and until then `docker logs -f plsc` shows no output.